### PR TITLE
Fix bug in PIN plugin using xsavec

### DIFF
--- a/tracers/pin/qirapin.cpp
+++ b/tracers/pin/qirapin.cpp
@@ -193,9 +193,9 @@ static inline void mmap_close(MMAPFILE fd) {
 	close(fd);
 }
 static void *mmap_map(MMAPFILE fd, size_t size, size_t offset = 0) {
-	USIZE thesize=0;
-	OS_FileSizeFD(fd,&thesize);
-	if(static_cast<size_t>(thesize) < offset+size)
+	struct stat st;
+	fstat(fd, &st);
+	if(static_cast<size_t>(st.st_size) < offset+size)
 		ftruncate(fd, offset+size);
 
 	void *ret = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, offset);
@@ -442,7 +442,7 @@ public:
 #ifndef TARGET_WINDOWS
 	void fork_before(THREADID tid) {
 		PIN_GetLock(&lock, 0);
-		// sync(); // commented out to be compatible with later PIN versions. Seems to work...
+		sync();
 		// TODO: Close all files, reopen later
 		// I think this is only required for the current tid's data structure.
 	}
@@ -647,6 +647,12 @@ VOID Instruction(INS ins, VOID *v) {
 
 	if(INS_Mnemonic(ins) == "XSAVE") {
 		// Avoids "Cannot use IARG_MEMORYWRITE_SIZE on non-standard memory access of instruction at 0xfoo: xsave ptr [rsp]"
+		// TODO: Bitch at the PIN folks.
+		return;
+	}
+
+	if(INS_Mnemonic(ins) == "XSAVEC") {
+		// Avoids "Cannot use IARG_MEMORYWRITE_SIZE on non-standard memory access of instruction at 0xfoo: xsavec ptr [rsp]"
 		// TODO: Bitch at the PIN folks.
 		return;
 	}

--- a/tracers/pin/qirapin.cpp
+++ b/tracers/pin/qirapin.cpp
@@ -442,7 +442,7 @@ public:
 #ifndef TARGET_WINDOWS
 	void fork_before(THREADID tid) {
 		PIN_GetLock(&lock, 0);
-		//sync(); // commented out to be compatible with later PIN versions. Seems to work...
+		//sync();// commented out to be compatible with later PIN versions. Seems to work...
 		// TODO: Close all files, reopen later
 		// I think this is only required for the current tid's data structure.
 	}

--- a/tracers/pin/qirapin.cpp
+++ b/tracers/pin/qirapin.cpp
@@ -442,7 +442,7 @@ public:
 #ifndef TARGET_WINDOWS
 	void fork_before(THREADID tid) {
 		PIN_GetLock(&lock, 0);
-		//sync();// commented out to be compatible with later PIN versions. Seems to work...
+		// sync(); // commented out to be compatible with later PIN versions. Seems to work...
 		// TODO: Close all files, reopen later
 		// I think this is only required for the current tid's data structure.
 	}

--- a/tracers/pin/qirapin.cpp
+++ b/tracers/pin/qirapin.cpp
@@ -193,9 +193,11 @@ static inline void mmap_close(MMAPFILE fd) {
 	close(fd);
 }
 static void *mmap_map(MMAPFILE fd, size_t size, size_t offset = 0) {
-	struct stat st;
-	fstat(fd, &st);
-	if(static_cast<size_t>(st.st_size) < offset+size)
+	//struct stat st;
+	//fstat(fd, &st);
+	USIZE thesize=0;
+	OS_FileSizeFD(fd,&thesize);
+	if(static_cast<size_t>(thesize) < offset+size)
 		ftruncate(fd, offset+size);
 
 	void *ret = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, offset);
@@ -442,7 +444,7 @@ public:
 #ifndef TARGET_WINDOWS
 	void fork_before(THREADID tid) {
 		PIN_GetLock(&lock, 0);
-		sync();
+		//sync();
 		// TODO: Close all files, reopen later
 		// I think this is only required for the current tid's data structure.
 	}
@@ -650,7 +652,6 @@ VOID Instruction(INS ins, VOID *v) {
 		// TODO: Bitch at the PIN folks.
 		return;
 	}
-
 	if(INS_Mnemonic(ins) == "XSAVEC") {
 		// Avoids "Cannot use IARG_MEMORYWRITE_SIZE on non-standard memory access of instruction at 0xfoo: xsavec ptr [rsp]"
 		// TODO: Bitch at the PIN folks.
@@ -975,4 +976,3 @@ int main(int argc, char *argv[]) {
 	process_state.init(PIN_GetPid());
 	PIN_StartProgram(); // Note that this unwinds the stack!
 }
-

--- a/tracers/pin/qirapin.cpp
+++ b/tracers/pin/qirapin.cpp
@@ -193,8 +193,6 @@ static inline void mmap_close(MMAPFILE fd) {
 	close(fd);
 }
 static void *mmap_map(MMAPFILE fd, size_t size, size_t offset = 0) {
-	//struct stat st;
-	//fstat(fd, &st);
 	USIZE thesize=0;
 	OS_FileSizeFD(fd,&thesize);
 	if(static_cast<size_t>(thesize) < offset+size)
@@ -444,7 +442,7 @@ public:
 #ifndef TARGET_WINDOWS
 	void fork_before(THREADID tid) {
 		PIN_GetLock(&lock, 0);
-		//sync();
+		//sync(); // commented out to be compatible with later PIN versions. Seems to work...
 		// TODO: Close all files, reopen later
 		// I think this is only required for the current tid's data structure.
 	}


### PR DESCRIPTION
There is already a patch here for the xsave instruction. I came across an executable that would fail the PIN tracing plugin with an xsavec error message. This fixes that.